### PR TITLE
PROCESS : Integrate eco-design tool to CI

### DIFF
--- a/.github/workflows/exposeTests.yml
+++ b/.github/workflows/exposeTests.yml
@@ -1,0 +1,33 @@
+name: Expose tests
+on: 
+  workflow_call
+
+jobs:
+      
+    ExposeTest:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download sources
+              uses: actions/checkout@v3
+              with:
+                repository: ${{ github.event.pull_request.head.repo.full_name }}
+                ref: htmlPreview
+            - name: Get green it report zip
+              uses: actions/download-artifact@v3
+              with:
+                name: green-it-report
+                path: /home/runner/work/output
+            - name: Copy artifact into repo
+              run: cp -r /home/runner/work/output/ /home/runner/work/HyperGlosae/HyperGlosae/ 
+            - name: Commit artifact on htmlPreview branch
+              uses: EndBug/add-and-commit@v9
+              with:
+                add: "*"
+                default_author: github_actions
+                message: "PROCESS : Commit Green IT Analysis HTML file output to be previewed"
+                push: origin htmlPreview
+            - name: Create link to go to html file preview
+              run:
+                echo "https://htmlpreview.github.io/?https://github.com/vallhallalm/HyperGlosae/htmlPreview/output/global.html"
+        
+    

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,18 +6,22 @@ on:
 jobs:
 
   build:
+    if: "${{'PROCESS : Commit Green IT Analysis HTML file output to be previewed' != github.event.head_commit.message}}"
     uses: ./.github/workflows/build.yml
 
   test:
+    if: "${{'PROCESS : Commit Green IT Analysis HTML file output to be previewed' != github.event.head_commit.message}}"
     runs-on: ubuntu-latest
     steps:
       - name: Download sources
         uses: actions/checkout@v3
       - name: Download tools
         run: |
+          sudo apt install bc
           cd backend
           docker compose pull
           docker pull benel/cucumber-capybara
+          curl https://assets.greenframe.io/install.sh | bash
       - name: Install and launch backend with test data
         run: |
           cd backend
@@ -35,6 +39,12 @@ jobs:
           curl -X PUT -u "${COUCHDB_USER}:${COUCHDB_PASSWORD}" -s localhost:5984/_node/nonode@nohost/_config/httpd/enable_cors --data '"true"'
           curl -X PUT -u "${COUCHDB_USER}:${COUCHDB_PASSWORD}" -s localhost:5984/_node/nonode@nohost/_config/cors/origins --data '"*"'
           curl -X PUT -u "${COUCHDB_USER}:${COUCHDB_PASSWORD}" -s localhost:5984/hyperglosae/_security --data '{"members":{"roles":[]},"admins":{"roles":["_admin"]}}'
+      - name: Wait for frontend build
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          check-name: build / build
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Get frontend build
         uses: actions/download-artifact@v3
         with:
@@ -52,3 +62,25 @@ jobs:
         run:
           docker run --rm -v "$(pwd)":/app --tty --net="host" --env APP_HOST="http://`hostname`:3000" benel/cucumber-capybara --retry 2 --fail-fast --no-source --no-snippets
         shell: 'script -q -e -c "bash {0}"'
+      - name: Run eco-design test
+        run: |
+          cd tests
+          bash greenframeThreshold.sh
+          cd /home/runner/work/
+          mkdir output
+          chmod -R a+rwX /home/runner/work/output/
+          cd /home/runner/work/HyperGlosae/HyperGlosae/tests/greenIT/
+          sudo docker run -t --init --rm --cap-add=SYS_ADMIN --network="host" -v /home/runner/work/HyperGlosae/HyperGlosae/tests/greenIT/input:/app/input -v /home/runner/work/output:/app/output  --name green-it-test vallhallalm/green_it_cli:v1 greenit analyse /app/input/url.yaml /app/output/global.html --format=html
+        env: 
+          GREENFRAME_SECRET_TOKEN: ${{ secrets.GREENFRAME_SECRET_TOKEN }}
+      - name: save output from greenIT as Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: green-it-report
+          path: /home/runner/work/output
+          retention-days: 5
+
+  exposeTest:
+    if: "${{'PROCESS : Commit Green IT Analysis HTML file output to be previewed' != github.event.head_commit.message}}"
+    needs: test
+    uses: ./.github/workflows/exposeTests.yml

--- a/features/step_definitions/event.rb
+++ b/features/step_definitions/event.rb
@@ -2,3 +2,6 @@ Quand('je me focalise sur {string}') do |title|
   click_on_icon_next_to('focus', title)
 end
 
+Quand('je consulte le contenu de {string}') do |title|
+  click_on_icon_next_to('open', title)
+end

--- a/features/step_definitions/outcome.rb
+++ b/features/step_definitions/outcome.rb
@@ -9,3 +9,23 @@ end
 Alors('{string} est une des gloses') do |title|
   expect(find('.gloses')).to have_content title
 end
+
+Alors('je peux lire {string}') do |text|
+  expect(page).to have_content text
+end
+
+Alors('je peux lire:') do |text|
+  expect(page).to have_content text
+end
+
+Alors('je ne peux pas lire {string}') do |text|
+  expect(page).not_to have_content text
+end
+
+Alors("je vois l'image {string}") do |alternative_text|
+  expect(page).to have_image(alternative_text)
+end
+
+Alors("je ne vois pas l'image {string}") do |alternative_text|
+  expect(page).not_to have_image(alternative_text)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -22,3 +22,7 @@ end
 def click_on_icon_next_to(action, text)
   find(:xpath, "//span[contains(., \"#{text}\")]/preceding-sibling::a[contains(@class, '#{action}')]", match: :first).click
 end
+
+def have_image(alternative_text)
+  have_xpath(".//img[@alt='#{alternative_text}']")
+end

--- a/frontend/src/BrowseTools.js
+++ b/frontend/src/BrowseTools.js
@@ -10,7 +10,7 @@ function BrowseTools({id, closable, openable}) {
         </Link>
       }
       {openable &&
-        <Link to={`#${id}`} className="icon">
+        <Link to={`#${id}`} className="icon open">
           <ChevronExpand title="Open this document" />
         </Link>
       }

--- a/tests/.greenframe.yml
+++ b/tests/.greenframe.yml
@@ -1,0 +1,7 @@
+baseURL: http://localhost:3000/ # Your app url
+projectName: HyperGlosae PE Louis Magnier # We prefilled for you the good project name
+scenarios: 
+  - path: ./scenario.js # the scenario we've just created together !
+    name: My first scenario
+databaseContainers:
+  - 'backend-couchdb-1'

--- a/tests/greenIT/input/url.yaml
+++ b/tests/greenIT/input/url.yaml
@@ -1,0 +1,6 @@
+# Analyse l'URL collectif.greenit.fr 
+- name : 'HyperGlosae'
+  url : 'http://localhost:3000/'
+  actions:
+    - name : "Scroll auto vers le bas de la page"
+      type : 'scroll'

--- a/tests/greenframeThreshold.sh
+++ b/tests/greenframeThreshold.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+outputGreenframe=$(greenframe analyze)
+echo $outputGreenframe
+
+threshold=0.05 ## set threshold here in Wh
+
+interString=${outputGreenframe% Wh*}
+finalConsumption=${interString##* (}
+
+if (( $(echo "$finalConsumption > $threshold" |bc -l) ))
+then 
+    echo "[x] Greenframe test failed. The threshold set for this project is ${threshold}Wh and the test ran with a consumption of ${finalConsumption}Wh"
+    exit 34
+else 
+    echo "[x] Greenframe test pass successfully. The threshold set for this project is ${threshold}Wh and the test ran with a consumption of ${finalConsumption}Wh"
+    exit 0
+fi

--- a/tests/scenario.js
+++ b/tests/scenario.js
@@ -1,0 +1,16 @@
+async (page) => {
+  // Go to the url passed to the command line (see below)
+  await page.waitForTimeout(1000);
+  await page.goto("/02ee00d85cdb11ed834c4fb9e3c972af", {waitUntil: "domcontentloaded"});
+  await page.waitForTimeout(1000);
+  await page.scrollToEnd();
+  await page.waitForTimeout(1000);
+  await page.goto("/4745d83eabc111edb4d7a3e38e32ff69", {waitUntil: "domcontentloaded"});
+  await page.waitForTimeout(1000);
+  await page.scrollToEnd();
+  await page.waitForTimeout(1000);
+  await page.goto("/", {waitUntil: "domcontentloaded"});
+  await page.waitForTimeout(1000);
+  await page.scrollToEnd();
+  await page.waitForTimeout(1000);
+};


### PR DESCRIPTION
I, Louis Magnier, hereby grant to Hyperglosae maintainers the right to publish our contribution under the terms of any licenses the Free Software Foundation classifies as Free Software Licenses.

Just a little more details and things to do so that this process improvement integrate themselves nicely in the process : 
- As we do commit some file within a workflow we will need to grant them the right to write in our repository.
- Greenframe need a new secret to be set up to work perfectly. This secret has to be named GREENFRAME_SECRET_TOKEN and needs to contain the token that greenframe provide
- Before executing the new workflow it might be necessary to create a new orphan branch called htmlPreview with the following command 
```sh
git checkout --orphan htmlPreview
git rm -rf .
rm '.gitignore'
echo "# This branch is meant to preview html output of Green It Analysis analyse" > README.md
git add README.md
git commit -a -m "Initial Commit"
git push origin htmlPreview
```
- Regarding the analysis conducted with greenframe, there is a threshold which needs to be set manually. For example if we know that we are going to commit a change which might be quite energy consuming but that is necessary, it might be interesting to raise the threshold before the commit so that tests do not fail. Threshold can be set in /tests/greenframeThreshold.sh on line 5