### PR TITLE
FIX: A document may refer owned documents and not owned documents (fixes #264).

### DIFF
--- a/frontend/src/components/Graph.jsx
+++ b/frontend/src/components/Graph.jsx
@@ -16,14 +16,14 @@ function Graph({ rawDocs, displayedDocs }) {
     ));
     const typeColorScale = scaleOrdinal(types, schemeCategory10);
     const nodes = docs.map(([id, title]) => ({id, title}));
-    const links = docs.filter(d => d[2] !== undefined && d[2].map(l => l.object).every(o => displayedDocs.includes(o.split('#')[0])))
-      .flatMap(d =>
-        d[2].map(l => ({
-          source: d[0],
-          type: l.verb,
-          target: l.object.split('#')[0]
-        }))
-      );
+    const links = docs.flatMap(d =>(d[2] || [])
+      .filter(l => displayedDocs.includes(l.object.split('#')[0]))
+      .map(l => ({
+        source: d[0],
+        type: l.verb,
+        target: l.object.split('#')[0]
+      }))
+    );
 
     const simulation = forceSimulation(nodes)
       .force('link', forceLink(links).id(d => d.id))


### PR DESCRIPTION
The problem with the links came from the use of the `.every` operator, which returned true only when all referenced documents were owned. As a result, any document that referenced both owned and unowned documents was excluded from the `links` array.

I, Corentin Chartier, hereby grant to Hyperglosae maintainers the right to publish my contribution under the terms of any licenses the Free Software Foundation classifies as Free Software Licenses.