### PR TITLE
FIX: Fragment comment placeholder (see #337)... ... should be the horizontal ellipsis character.

### DIFF
--- a/frontend/scenarios/comment_fragment.feature
+++ b/frontend/scenarios/comment_fragment.feature
@@ -14,5 +14,5 @@ Scénario: de texte
   Alors la glose est ouverte en mode édition et contient :
   """
   [plusieurs personnes se présentent à moi. Ayant identifié que je suis nouveau, elles me souhaitent la bienvenue]
-  <COMMENT>
+  …
   """

--- a/frontend/src/components/EditableText.jsx
+++ b/frontend/src/components/EditableText.jsx
@@ -38,7 +38,7 @@ function EditableText({id, text, rubric, isPartOf, links, fragment, setFragment,
       updateEditedDocument()
         .then((x) => {
           let existingText = parseFirstPassage(x.text);
-          setEditedText((existingText && `${existingText}\n\n`) + fragment + '<COMMENT>');
+          setEditedText((existingText && `${existingText}\n\n`) + fragment + '…');
           setBeingEdited(true);
           setFragment();
           setHasBeenChanged(true);


### PR DESCRIPTION
I, Luis Salazar, hereby grant to Hyperglosae maintainers the right to publish our contribution under the terms of any licenses the Free Software Foundation classifies as Free Software Licenses.

